### PR TITLE
doc: blackarch install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pacman -S certsync
 
 All OS distribution packages:
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/certsync.svg)](https://repology.org/project/certsync/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/certsync-ntds.svg)](https://repology.org/project/certsync-ntds/versions)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,29 @@ Contrary to what we may think, the attack is not at all slower.
 
 ## Installation
 
+Locally:
+
 ```text
 git clone https://github.com/zblurx/certsync
 cd certsync
 pip install .
 ```
 
-or 
+From Pypi:
 
 ```text
 pip install certsync
 ```
+
+From BlackArch:
+
+```text
+pacman -S certsync
+```
+
+All OS distribution packages:
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/certsync.svg)](https://repology.org/project/certsync/versions)
 
 ## Usage
 


### PR DESCRIPTION
I [added certsync to BlackArch Linux](https://github.com/BlackArch/blackarch/pull/3982/files)

PS: for repology badge the macport entry is a false positive due to a name conflict, [I requested a split](https://repology.org/project/certsync/report).