### PR TITLE
Add of the 'esc1' method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "certsync"
-version = "0.1.6"
-description = "Dump NTDS with golden certificates and UnPAC the hash"
+version = "0.2.0"
+description = "Retrieve domain users hash by getting certificates and UnPAC the hash."
 readme = "README.md"
 homepage = "https://github.com/zblurx/certsync"
 repository = "https://github.com/zblurx/certsync"
 keywords = ["ntds", "certificate", "hashes"]
-authors = ["zblurx <seigneuret.thomas@protonmail.com>"]
+authors = ["zblurx <seigneuret.thomas@protonmail.com>", "p-alu <paul.saladin@outlook.com>"]
 license = "MIT"
 classifiers = [
     "Topic :: Security",


### PR DESCRIPTION
Thank you for the original work.

I wanted to add another way to perform the same kind of actions without dumping information from the CA.
The fact is that when CA key is dumped, you need to fully rebuild the PKI if you want to be sure the dumped key is no longer valid, which can be a mess

I added an 'esc1' action which let the user request certificates with `alt_upn` for the collected domain users. By default, the `SubCA` template is used (almost always enabled and has `EnrolleeSuppliesSubject` flag). The user might chose the template he wants to request with the already present `-template` option.

This action may take much more time than the `golden` one.

![image](https://github.com/user-attachments/assets/4fea141a-2dde-498c-b274-3c19beca0f31)
